### PR TITLE
gen-man: Fix usage of git describe

### DIFF
--- a/gen-man.sh
+++ b/gen-man.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-pod2man -c "" -r "`git describe`" reposloc > reposloc.1
+pod2man -c "" -r "`git describe --tags`" reposloc > reposloc.1


### PR DESCRIPTION
By default, git-describe(1) references only annotated tags. The two most recent releases are not annotated, so git-describe reports something to the effect of v1.1.1-X-<HASH>, when checked out at v1.3.